### PR TITLE
Allow the gem to be used on Rails 6.1

### DIFF
--- a/knifeswitch.gemspec
+++ b/knifeswitch.gemspec
@@ -18,7 +18,7 @@ https://martinfowler.com/bliki/CircuitBreaker.html}
 
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  spec.add_dependency "rails", ">= 5.2", "< 6.1"
+  spec.add_dependency "rails", ">= 5.2"
 
   spec.add_development_dependency "mysql2"
 end

--- a/lib/knifeswitch/version.rb
+++ b/lib/knifeswitch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Knifeswitch
-  VERSION = '1.3.0'
+  VERSION = '1.3.1'
 end


### PR DESCRIPTION
I want to start testing this gem in rails 6.1. After talking to the author of the gemspec, it seems like the `< 6.1` dependency was just put in out of fear. I'd like to remove it so I can start testing with rails 6.1 in another project.

I'm not sure if the version bump to 1.3.1 is the right thing to do since nothing changed but the gemspec. For example RPM has a specific field that specifies the version of the package itself and not the packaged software. I couldn't quite find an equivalent in rubygems for this so I just bumped the library version. Please let me know if rubygems does have such a feature that I overlooked.