### PR TITLE
Do not checkin if conn is nil

### DIFF
--- a/lib/knifeswitch/circuit.rb
+++ b/lib/knifeswitch/circuit.rb
@@ -170,7 +170,8 @@ module Knifeswitch
           @conn = ActiveRecord::Base.connection_pool.checkout
           yield(@conn)
         ensure
-          ActiveRecord::Base.connection_pool.checkin(@conn)
+          # @conn can be nil if ActiveRecord::Base.connection_pool.checkout fails due to ActiveRecord::ConnectionTimeoutError
+          ActiveRecord::Base.connection_pool.checkin(@conn) if @conn
           @conn = nil
         end
       end

--- a/lib/knifeswitch/version.rb
+++ b/lib/knifeswitch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Knifeswitch
-  VERSION = '1.3.1'
+  VERSION = '1.3.2'
 end


### PR DESCRIPTION
If `@conn = ActiveRecord::Base.connection_pool.checkout` raises `ActiveRecord::ConnectionTimeoutError`, this `ActiveRecord::Base.connection_pool.checkin(@conn)` will raise `NoMethodError` inside ActiveRecord: https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb#L353

When `@conn` is nil `ActiveRecord::Base.connection_pool.checkin(@conn)` should be skipped because there is nothing to checkin in that case.